### PR TITLE
Introduce short-hand codes for checks

### DIFF
--- a/docs/source/linters.rst
+++ b/docs/source/linters.rst
@@ -3,13 +3,13 @@
 Linters
 =======
 
-``ensure_timestamps``
+``ensure_timestamps (L001)``
 ---------------------
 
 Ensure that a job is configured to produce timestamps in its console
 output.
 
-``ensure_workspace_cleanup``
+``ensure_workspace_cleanup (L002)``
 ----------------------------
 
 Ensure that a job is configured to clean the workspace prior to execution.
@@ -19,7 +19,7 @@ Configuration Options
 
 No configuration options.
 
-``check_env_inject``
+``check_env_inject (L003)``
 --------------------
 
 If required environment settings are configured (see below), ensure
@@ -34,7 +34,7 @@ Configuration Options
     A comma-separated list of environment variable setting lines that
     should be present in job environments.
 
-``check_for_empty_shell``
+``check_for_empty_shell (L006)``
 -------------------------
 
 Ensure that all shell builders in a job have some content.
@@ -44,19 +44,24 @@ Configuration Options
 
 No configuration options.
 
-``check_job_references``
+``check_job_references (L004)``
 ------------------------
 
 Ensure that all job references have a target within the generated
 Jenkins configuration.  Currently, this checks the ``trigger-builds``
 builder.
 
+``check_column_configuration (L005)``
+------------------------
+
+Ensure that each list view has at least one column configured.
+
 Configuration Options
 ~~~~~~~~~~~~~~~~~~~~~
 
 No configuration options.
 
-``check_shebang``
+``check_shebang (L007)``
 -----------------
 
 Ensure that all shell builders in a job have an appropriate shebang.

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -7,7 +7,7 @@ Standalone
 When installed, the ``jenkins-job-linter`` script will be available on
 your PATH.  Running it is as simple as::
 
-    jenkins-job-linter <path>
+    jenkins-job-linter lint-directory <path>
 
 ``<path>`` should be a directory containing only Jenkins job XML files
 (a la the output of ``jenkins-jobs test -o <path>``) as all files in
@@ -17,7 +17,19 @@ the directory will be linted.
     You are responsible for generating the XML that jenkins-job-linter
     will run against in standalone mode.  If you don't want to do that,
     take a look at :ref:`jenkins_jobs_lint` which will do it for you if
-    you are using Jenkins Job Builder.
+    you are using Jenkins Job Builder. You can also run
+    ``jenkins-jobs test -o xml jenkins/jobs`` which will compile all job
+    in `jenkins/jobs` directory to a directory named `xml`.
+
+``list-linters``
+---------------------
+::
+
+        jenkins-job-linter list-linters
+
+List all linters, their descriptions, default configuration and their short
+codes.
+
 
 .. _jenkins_jobs_lint:
 

--- a/integration_tests/test_check_env_inject.yaml
+++ b/integration_tests/test_check_env_inject.yaml
@@ -28,7 +28,7 @@ cases:
           [job_linter:check_env_inject]
           required_environment_settings = SET=this
       expected_output: |
-        test-job: checking environment variable injection: FAIL: Injection unexpectedly unconfigured
+        test-job: (L003) checking environment variable injection: FAIL: Injection unexpectedly unconfigured
       expect_success: False
 
     - name: test_single_configured_value_failure
@@ -49,7 +49,7 @@ cases:
           [job_linter:check_env_inject]
           required_environment_settings = SET=this
       expected_output: |
-        test-job: checking environment variable injection: FAIL: Did not find SET=this
+        test-job: (L003) checking environment variable injection: FAIL: Did not find SET=this
       expect_success: False
 
     - name: test_happy_path
@@ -91,7 +91,7 @@ cases:
           [job_linter:check_env_inject]
           required_environment_settings = SET=this, OR=this
       expected_output: |
-        test-job: checking environment variable injection: FAIL: Did not find SET=this
+        test-job: (L003) checking environment variable injection: FAIL: Did not find SET=this
       expect_success: False
 
     - name: test_partial_match_still_fails
@@ -114,7 +114,7 @@ cases:
           [job_linter:check_env_inject]
           required_environment_settings = SET=this, OR=this
       expected_output: |
-        test-job: checking environment variable injection: FAIL: Did not find OR=this
+        test-job: (L003) checking environment variable injection: FAIL: Did not find OR=this
       expect_success: False
 
     - name: test_happy_path_with_multiple_things_configured

--- a/integration_tests/test_check_for_empty_shell.yaml
+++ b/integration_tests/test_check_for_empty_shell.yaml
@@ -14,7 +14,7 @@ cases:
               builders:
                 - shell: ""
       expected_output: |
-        test-job: checking shell builder shell scripts are not empty: FAIL
+        test-job: (L006) checking shell builder shell scripts are not empty: FAIL
       expect_success: False
 
     - name: test_multiple_shell_builders
@@ -28,5 +28,5 @@ cases:
                 - shell: "just some code"
                 - shell: ""
       expected_output: |
-        test-job: checking shell builder shell scripts are not empty: FAIL
+        test-job: (L006) checking shell builder shell scripts are not empty: FAIL
       expect_success: False

--- a/integration_tests/test_check_job_references.yaml
+++ b/integration_tests/test_check_job_references.yaml
@@ -59,7 +59,7 @@ cases:
                   - trigger-builds:
                       - project: missing-job
       expected_output: |
-          test-job: checking job references: FAIL: Reference to missing object missing-job
+          test-job: (L004) checking job references: FAIL: Reference to missing object missing-job
       expect_success: False
 
     - name: test_missing_trigger_builds_builder_target_errors_with_csv
@@ -74,7 +74,7 @@ cases:
                   - trigger-builds:
                       - project: missing-job,existent-job
       expected_output: |
-          test-job: checking job references: FAIL: Reference to missing object missing-job
+          test-job: (L004) checking job references: FAIL: Reference to missing object missing-job
       expect_success: False
 
     - name: test_missing_trigger_builds_builder_target_errors_with_space_separated_csv
@@ -89,7 +89,7 @@ cases:
                   - trigger-builds:
                       - project: missing-job, existent-job
       expected_output: |
-          test-job: checking job references: FAIL: Reference to missing object missing-job
+          test-job: (L004) checking job references: FAIL: Reference to missing object missing-job
       expect_success: False
 
     - name: test_multiple_projects_in_one_builder
@@ -105,7 +105,7 @@ cases:
           - job:
               name: existent-job
       expected_output: |
-          test-job: checking job references: FAIL: Reference to missing object missing-job
+          test-job: (L004) checking job references: FAIL: Reference to missing object missing-job
       expect_success: False
 
     - name: test_multiple_builders_in_one_job
@@ -122,7 +122,7 @@ cases:
           - job:
               name: existent-job
       expected_output: |
-          test-job: checking job references: FAIL: Reference to missing object missing-job
+          test-job: (L004) checking job references: FAIL: Reference to missing object missing-job
       expect_success: False
 
     - name: test_unconfigured_reference
@@ -135,5 +135,5 @@ cases:
                   - trigger-builds:
                       - project:
       expected_output: |
-          test-job: checking job references: FAIL: No reference configured
+          test-job: (L004) checking job references: FAIL: No reference configured
       expect_success: False

--- a/integration_tests/test_check_shebang.yaml
+++ b/integration_tests/test_check_shebang.yaml
@@ -13,7 +13,7 @@ cases:
               builders:
                 - shell: "#!/bin/sh -ex"
       expected_output: |
-        test-job: checking shebang of shell builders: FAIL: Shebang is #!/bin/sh -ex
+        test-job: (L007) checking shebang of shell builders: FAIL: Shebang is #!/bin/sh -ex
       expect_success: False
 
     - name: test_shell_shebang_with_no_options
@@ -25,7 +25,7 @@ cases:
               builders:
                 - shell: "#!/bin/sh"
       expected_output: |
-        test-job: checking shebang of shell builders: FAIL: Shebang is #!/bin/sh
+        test-job: (L007) checking shebang of shell builders: FAIL: Shebang is #!/bin/sh
       expect_success: False
 
     - name: test_shell_shebang_with_no_recognisable_options
@@ -37,7 +37,7 @@ cases:
               builders:
                 - shell: "#!/bin/sh not opts"
       expected_output: |
-        test-job: checking shebang of shell builders: FAIL: Shebang is #!/bin/sh not opts
+        test-job: (L007) checking shebang of shell builders: FAIL: Shebang is #!/bin/sh not opts
       expect_success: False
 
     - name: test_non_shell_shebang
@@ -77,7 +77,7 @@ cases:
           [job_linter:check_shebang]
           allow_default_shebang = false
       expected_output: |
-        test-job: checking shebang of shell builders: FAIL: Shebang is Jenkins' default
+        test-job: (L007) checking shebang of shell builders: FAIL: Shebang is Jenkins' default
       expect_success: False
 
     - name: test_check_shebang_no_required_shell_options
@@ -112,7 +112,7 @@ cases:
           [job_linter:check_shebang]
           required_shell_options = opts
       expected_output: |
-        test-job: checking shebang of shell builders: FAIL: Shebang is #!/bin/sh -opt
+        test-job: (L007) checking shebang of shell builders: FAIL: Shebang is #!/bin/sh -opt
       expect_success: False
 
     - name: test_check_shebang_required_shell_options_success

--- a/integration_tests/test_ensure_timestamps.yaml
+++ b/integration_tests/test_ensure_timestamps.yaml
@@ -12,5 +12,5 @@ cases:
           - job:
               name: test-job
       expected_output: |
-        test-job: checking for timestamps: FAIL
+        test-job: (L001) checking for timestamps: FAIL
       expect_success: False

--- a/integration_tests/test_ensure_workspace_cleanup.yaml
+++ b/integration_tests/test_ensure_workspace_cleanup.yaml
@@ -12,5 +12,5 @@ cases:
           - job:
               name: test-job
       expected_output: |
-        test-job: checking for workspace cleanup: FAIL
+        test-job: (L002) checking for workspace cleanup: FAIL
       expect_success: False

--- a/integration_tests/test_linter_selection.yaml
+++ b/integration_tests/test_linter_selection.yaml
@@ -42,5 +42,5 @@ cases:
           only_run=
             ensure_timestamps
       expected_output: |
-        test-job: checking for timestamps: FAIL
+        test-job: (L001) checking for timestamps: FAIL
       expect_success: False

--- a/integration_tests/test_views.yaml
+++ b/integration_tests/test_views.yaml
@@ -32,7 +32,7 @@ cases:
               view-type: list
               columns: []
       expected_output: |
-          test-view: checking column configuration: FAIL: No columns configured
+          test-view: (L005) checking column configuration: FAIL: No columns configured
       expect_success: False
       runners_to_skip:
           - actual_jenkins  # Jenkins rejects the generated config with a 500

--- a/jenkins_job_linter/__init__.py
+++ b/jenkins_job_linter/__init__.py
@@ -23,7 +23,7 @@ import click
 import jenkins
 
 from jenkins_job_linter.config import _filter_config, GetListConfigParser
-from jenkins_job_linter.linters import LINTERS
+from jenkins_job_linter.linters import LINTERS, LINTER_SHORT_CODES
 from jenkins_job_linter.models import LintContext, RunContext
 
 
@@ -41,7 +41,8 @@ def lint_job_xml(ctx: RunContext, job_name: str, tree: ElementTree.ElementTree,
         result, text = linter(LintContext(section, ctx, tree)).check()
         if not result.value:
             success = False
-            output = '{}: {}: FAIL'.format(job_name, linter.description)
+            output = '{}: ({}) {}: FAIL'.format(job_name, linter.short_code,
+                                                linter.description)
             if text is not None:
                 output += ': {}'.format(text)
             print(output)
@@ -82,17 +83,63 @@ def lint_jobs_from_running_jenkins(jenkins_url: str, jenkins_username: str,
 
 @click.group()
 @click.option('--conf', type=click.Path(exists=True, dir_okay=False))
+@click.option('--select', default=[], metavar='<lint_short_code>',
+              type=click.STRING,
+              help='Select which linters, by short code, to run. '
+                   'A comma separated list is accepted'
+                   'If conf option is used then --select is not used.'
+                   'Use `list-linters` sub command to view list')
+@click.option('--ignore', default=[], metavar='<lint_short_code>',
+              type=click.STRING,
+              help='Select which linters, by short code, to ignore. '
+                   'A comma separated list is accepted'
+                   'If conf option is used then --ignore is not used'
+                   'Use `list-linters` sub command to view list')
 @click.pass_context
-def main(ctx: click.Context, conf: Optional[str] = None) -> None:
+def main(ctx: click.Context, conf: Optional[str] = None,
+         select: Optional[str] = None,
+         ignore: Optional[str] = None) -> None:
     """jenkins-job-linter: check your Jenkins jobs for common errors."""
     config = ConfigParser()
     if conf is not None:
         config.read(conf)
+    else:
+        if select:
+            config.add_section('job_linter')
+            only_run = []
+            for linter_short_code in select.split(','):
+                if linter_short_code in LINTER_SHORT_CODES:
+                    only_run.append(LINTER_SHORT_CODES[linter_short_code])
+
+            config.set('job_linter', 'only_run', ','.join(only_run))
+        if ignore:
+            config.add_section('job_linter')
+            disable_linters = []
+            for linter_short_code in ignore.split(','):
+                if linter_short_code in LINTER_SHORT_CODES:
+                    disable_linters.append(
+                            LINTER_SHORT_CODES[linter_short_code])
+
+            config.set('job_linter', 'disable_linters',
+                       ','.join(disable_linters))
+
     ctx.obj = config
 
 
 # Required until https://github.com/python/typeshed/issues/1918 is fixed
 main = cast(click.Group, main)
+
+
+@main.command(name='list-linters')
+@click.pass_context
+def list_linters(ctx: click.Context) -> None:
+    """List linters."""
+    for linter_name, linter in LINTERS.items():
+        print('* {}'.format(linter_name))
+        print('\tShort code:\n\t\t{}'.format(linter.short_code))
+        print('\tDescription:\n\t\t{}'.format(linter.description))
+        if linter.default_config:
+            print('\tDefault Config:\n\t\t{}'.format(linter.default_config))
 
 
 @main.command(name='lint-directory')

--- a/jenkins_job_linter/linters.py
+++ b/jenkins_job_linter/linters.py
@@ -41,6 +41,7 @@ class Linter:
     """A super-class capturing the common linting pattern."""
 
     default_config = {}  # type: Dict[str, Any]
+    short_code = None  # type: bool
 
     def __init__(self, ctx: LintContext) -> None:
         """
@@ -87,6 +88,7 @@ class ListViewLinter(Linter):
 class EnsureTimestamps(JobLinter):
     """Ensure that a job is configured with timestamp output."""
 
+    short_code = 'L001'
     description = 'checking for timestamps'
     _xpath = (
         './buildWrappers/hudson.plugins.timestamper.TimestamperBuildWrapper')
@@ -102,6 +104,7 @@ class EnsureTimestamps(JobLinter):
 class EnsureWorkspaceCleanup(JobLinter):
     """Ensure that a job workspace is cleaned before execution."""
 
+    short_code = 'L002'
     description = 'checking for workspace cleanup'
     _xpath = (
         './buildWrappers/hudson.plugins.ws__cleanup.PreBuildCleanup')
@@ -117,6 +120,7 @@ class EnsureWorkspaceCleanup(JobLinter):
 class CheckEnvInject(JobLinter):
     """Ensure that required environment variables are injected."""
 
+    short_code = 'L003'
     default_config = {
         'required_environment_settings': '',
     }
@@ -160,6 +164,7 @@ class CheckEnvInject(JobLinter):
 class CheckJobReferences(JobLinter):
     """Ensure that jobs referenced for triggering exist."""
 
+    short_code = 'L004'
     description = 'checking job references'
     _xpath = (
         './builders/hudson.plugins.parameterizedtrigger.TriggerBuilder/configs'
@@ -183,6 +188,7 @@ class CheckJobReferences(JobLinter):
 class CheckColumnConfiguration(ListViewLinter):
     """Ensure that each list view has at least one column configured."""
 
+    short_code = 'L005'
     description = 'checking column configuration'
     _xpath = './columns/*'
 
@@ -197,6 +203,7 @@ class CheckColumnConfiguration(ListViewLinter):
 class ShellBuilderLinter(JobLinter):
     """A linter that operates on the shell builders of jobs."""
 
+    short_code = 'L006'
     _xpath = './builders/hudson.tasks.Shell/command'
 
     def actual_check(self) -> LintCheckResult:
@@ -225,6 +232,7 @@ class ShellBuilderLinter(JobLinter):
 class CheckForEmptyShell(ShellBuilderLinter):
     """Ensure that shell builders in a job have some content."""
 
+    short_code = 'L006'
     description = 'checking shell builder shell scripts are not empty'
 
     def shell_check(self, shell_script: Optional[str]) -> Tuple[LintResult,
@@ -245,6 +253,7 @@ class CheckShebang(ShellBuilderLinter):
     Shell builders with no shebang or a non-shell shebang are skipped.
     """
 
+    short_code = 'L007'
     default_config = {
         'allow_default_shebang': True,
         'required_shell_options': 'eux',
@@ -296,3 +305,5 @@ class CheckShebang(ShellBuilderLinter):
 
 extension_manager = ExtensionManager(namespace='jjl.linters')
 LINTERS = {ext.name: ext.plugin for ext in extension_manager}
+LINTER_SHORT_CODES = {linter.short_code: linter_name
+                      for linter_name, linter in LINTERS.items()}


### PR DESCRIPTION
Like other linting tools do, each check that a linter performs should have a separate, distinct short code (e.g. J123, L123) which can be used for easily referring to issues.